### PR TITLE
Adding the UTF8 validation code to utf8-range module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library (utf8_range STATIC
 
 ##
 # A heavier-weight C++ wrapper that supports Abseil.
-add_library (utf8_validity STATIC utf8_validity.cc)
+add_library (utf8_validity STATIC utf8dfa.cpp utf8vec.cpp utf8_validity.cc)
 
 # Load Abseil dependency.
 if (NOT TARGET absl::strings)
@@ -38,9 +38,10 @@ if (utf8_range_ENABLE_TESTS)
   enable_testing()
 
   find_package(GTest REQUIRED)
+  include_directories(${GTEST_INCLUDE_DIRS})
 
   add_executable(tests utf8_validity_test.cc)
-  target_link_libraries(tests utf8_validity GTest::gmock_main)
+  target_link_libraries(tests utf8_validity gmock gmock_main)
 
   add_test(NAME utf8_validity_test COMMAND tests)
 
@@ -80,7 +81,7 @@ if (utf8_range_ENABLE_INSTALL)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
   # Install public headers explicitly.
-  install(FILES utf8_range.h utf8_validity.h
+  install(FILES utf8_range.h utf8_validity.h utf8.h utf8-simd.h utils.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 endif ()

--- a/main.c
+++ b/main.c
@@ -14,9 +14,15 @@ int utf8_boost(const unsigned char *data, int len);
 int utf8_lemire(const unsigned char *data, int len);
 int utf8_range(const unsigned char *data, int len);
 int utf8_range2(const unsigned char *data, int len);
+int utf8dfa_2dfa(const unsigned char*, int);
+int utf8dfa_5dfa(const unsigned char*, int);
 #ifdef __AVX2__
 int utf8_lemire_avx2(const unsigned char *data, int len);
 int utf8_range_avx2(const unsigned char *data, int len);
+int utf8vec_avx2(const unsigned char *data, int len);
+#endif
+#ifdef __AVX512F__
+int utf8vec_avx512(const unsigned char *data, int len);
 #endif
 
 static struct ftab {
@@ -43,6 +49,14 @@ static struct ftab {
         .name = "range2",
         .func = utf8_range2,
     },
+    {
+        .name = "utf8dfa_2dfa",
+        .func = utf8dfa_2dfa,
+    },
+    {
+        .name = "utf8dfa_5dfa",
+        .func = utf8dfa_5dfa,
+    },
 #ifdef __AVX2__
     {
         .name = "lemire_avx2",
@@ -51,6 +65,16 @@ static struct ftab {
     {
         .name = "range_avx2",
         .func = utf8_range_avx2,
+    },
+    {
+        .name = "utf8vec_avx2",
+        .func = utf8vec_avx2,
+    },
+#endif
+#ifdef __AVX512F__
+    {
+        .name = "utf8vec_avx-512",
+        .func = utf8vec_avx512,
     },
 #endif
 #ifdef BOOST

--- a/utf8-simd.h
+++ b/utf8-simd.h
@@ -1,0 +1,12 @@
+#pragma once
+
+bool u_utf8_2dfa(const uint8_t *buf, uint32_t len);
+bool u_utf8_5dfa(const uint8_t *buf, uint32_t len);
+
+#ifdef __AVX512F__
+bool u_utf8_d512(const uint8_t *buf, uint32_t len);
+#endif
+
+#ifdef __AVX2__
+bool u_utf8_d256(const uint8_t *buf, uint32_t len);
+#endif

--- a/utf8.h
+++ b/utf8.h
@@ -1,0 +1,27 @@
+#pragma once
+
+
+#ifdef _MSC_VER
+#define INLINE  __forceinline
+#elif defined (__GNUC__)
+#define INLINE __attribute__((always_inline)) inline
+#else
+#define INLINE inline
+#endif
+
+static INLINE const uint8_t *utf8MidBoundary(const uint8_t *start, const uint8_t *end, uint32_t ratio);
+
+static INLINE const uint8_t *utf8MidBoundary(const uint8_t *start, const uint8_t *end, uint32_t ratio) {
+    const uint8_t *mid = start + ((ratio - 1) * (end - start) + ratio - 1) / ratio;
+    // search for a utf8 boundary in the middle of the buffer
+    // make sure the second part of the buffer is proportionally the smallest
+    while (mid != end) {
+        uint32_t byte2 = *mid;
+        if ((byte2 & 0x80) == 0x00) break;
+        if ((byte2 & 0xc0) == 0xc0) break;
+        mid++;
+    }
+    return mid;
+}
+
+#undef INLINE

--- a/utf8_validity.cc
+++ b/utf8_validity.cc
@@ -23,6 +23,8 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
 
+#include "utf8-simd.h"
+
 #ifdef __SSE4_1__
 #include <emmintrin.h>
 #include <smmintrin.h>
@@ -450,7 +452,30 @@ size_t ValidUTF8(const char* data, size_t len) {
 }  // namespace
 
 bool IsStructurallyValid(absl::string_view str) {
+#ifdef __x86_64__
+  uint8_t* p = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str.data()));
+  int size = str.size();
+#ifdef __AVX512F__
+  // Use vectorization for large buffers much larger than the vector length
+  if (size > 64) {    
+    return u_utf8_d512(p, size);
+  }
+#elif defined( __AVX2__)
+  // Use vectorization for large buffers much larger than the vector length
+  if (size > 32) {
+    return u_utf8_d256(p, size);
+  }
+#else
+  // Use stitched dfa for buffers much larger than the chunks sizes  
+  if (size > 25) {
+    return u_utf8_5dfa(p, size);
+  }
+#endif
+  // short length, use a fast function with very low overhead
+  return u_utf8_2dfa(p, size);
+#else
   return ValidUTF8</*ReturnPosition=*/false>(str.data(), str.size());
+#endif
 }
 
 size_t SpanStructurallyValid(absl::string_view str) {

--- a/utf8_validity_test.cc
+++ b/utf8_validity_test.cc
@@ -46,6 +46,7 @@ TEST(Utf8Validity, IsStructurallyValid) {
   EXPECT_TRUE(IsStructurallyValid("ab\xc2\x81"));                   // 2-byte
   EXPECT_TRUE(IsStructurallyValid("a\xe2\x81\x81"));                // 3-byte
   EXPECT_TRUE(IsStructurallyValid("\xf2\x81\x81\x81"));             // 4
+  EXPECT_TRUE(IsStructurallyValid("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdd")); 
 
   // Test simple bad strings
   EXPECT_FALSE(IsStructurallyValid("abc\x80"));           // bad char

--- a/utf8dfa.cpp
+++ b/utf8dfa.cpp
@@ -1,0 +1,214 @@
+// --------------------------------------------------------------------------------
+// 
+// 
+// https://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+//
+//
+
+// Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+// --------------------------------------------------------------------------------
+// This code has been heavily modified for optimizations
+// - DFA changed to keep in rejected state 
+// - split the tables to remove an addition of 256
+// - divide and conquer : code stitching to benefit from OOO
+// - ....
+// --------------------------------------------------------------------------------
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
+
+#include "utf8.h"
+
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT_BIT 7
+#define UTF8_REJECT (1 << UTF8_REJECT_BIT)
+
+#define R UTF8_REJECT      // reject state
+
+static const uint8_t utf8d[] = {
+    // The first part of the table maps bytes to character classes that
+    // to reduce the size of the transition table and create bitmasks.
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,  9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+     7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+     8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+    10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8 };
+
+static const uint8_t utf8s[] = {
+    // The second part is a transition table that maps a combination
+    // of a state of the automaton and a character class to a state.
+    0,R,24,36,60,96,84,R,R,R,48,72,           // 0 ... 107 (state machine)
+    R,R,R,R,R,R,R,R,R,R,R,R,
+    R,0,R,R,R,R,R,0,R, 0,R,R,
+    R,24,R,R,R,R,R,24,R,24,R,R,
+    R,R,R,R,R,R,R,24,R,R,R,R,
+    R,24,R,R,R,R,R,R,R,24,R,R,
+    R,R,R,R,R,R,R,36,R,36,R,R,
+    R,36,R,R,R,R,R,36,R,36,R,R,
+    R,36,R,R,R,R,R,R,R,R,R,R,
+    R,R,R,R,R,R,R,R,R,R,           // 108 ... 127 (padding)
+    R,R,R,R,R,R,R,R,R,R,
+    R,R,R,R,R,R,R,R,R,R,R,R    // R ... 139 (rejected states)
+};
+
+#undef R
+
+#define FILTER_ASCII7 \
+do {  while (length && (*s & 0x80) == 0) { length--; s++; }   \
+   while (length && (*(s + length - 1) & 0x80) == 0) { length--; }  } while (0)
+
+bool u_utf8_2dfa(const uint8_t *s, uint32_t length) {
+    FILTER_ASCII7;
+    // cut the input buffer in 2 parts
+    const uint8_t *s1_end = s + length;
+    const uint8_t *s1_start = utf8MidBoundary(s, s1_end, 2);
+    const uint8_t *s0_start = s;
+    const uint8_t *s0_end = s1_start;
+    uint8_t byte0, byte1;
+    uint64_t state0, state1;
+
+    // the input buffer is now cut in 2 parts, 
+    // s1_start ... s1_end   (largest buffer)
+    // s2_start ... s2_end   (smallest buffer)
+
+    // now iterate over both buffers in parallel, take advantage of OOO execution 
+    state0 = UTF8_ACCEPT;
+    state1 = UTF8_ACCEPT;
+
+    // iterate over the smaller half-buffer
+    while (s1_start != s1_end) {
+        byte0 = *s0_start++;
+        byte1 = *s1_start++;
+        byte0 = utf8d[byte0];
+        byte1 = utf8d[byte1];
+        state0 = utf8s[state0 + byte0];
+        state1 = utf8s[state1 + byte1];
+    }
+
+    // finish the largest half-buffer
+    while (s0_start != s0_end) {
+        byte0 = *s0_start++;
+        byte0 = utf8d[byte0];
+        state0 = utf8s[state0 + byte0];
+    }
+
+    uint64_t fail = state0 | state1;
+    fail |= fail ? UTF8_REJECT : 0;
+    return (~fail) & UTF8_REJECT;
+}
+
+bool u_utf8_5dfa(const uint8_t *s, uint32_t length) {
+    FILTER_ASCII7;
+    // split the input buffer into 5 parts
+    const uint8_t *s4_end = s + length;
+    const uint8_t *s4_start = utf8MidBoundary(s, s4_end, 5);
+    const uint8_t *s3_end = s4_start;
+    const uint8_t *s2_start = utf8MidBoundary(s, s3_end, 2);
+    const uint8_t *s1_start = utf8MidBoundary(s, s2_start, 2);
+    const uint8_t *s3_start = utf8MidBoundary(s2_start, s3_end, 2);
+    const uint8_t *s1_end = s2_start;
+    const uint8_t *s0_start = s;
+    const uint8_t *s0_end = s1_start;
+    const uint8_t *s2_end = s3_start;
+
+    // get the length of the smallest buffer
+    uint32_t len0 = (uint32_t)(s0_end - s0_start);
+    uint32_t len1 = (uint32_t)(s1_end - s1_start);
+    len0 = len0 < len1 ? len0 : len1;
+    uint32_t len2 = (uint32_t)(s2_end - s2_start);
+    uint32_t len3 = (uint32_t)(s3_end - s3_start);
+    len2 = len2 < len3 ? len2 : len3;
+    uint32_t len4 = (uint32_t)(s4_end - s4_start);
+    uint32_t len = len0 < len2 ? len0 : len2;
+    len = len < len4 ? len : len4;
+
+    // the input buffer is now cut in 2 parts, 
+    // s1_start ... s1_end   (largest buffer)
+    // s2_start ... s2_end   (smallest buffer)
+
+    // now iterate over all buffers in parallel, take advantage of OOO execution 
+    uint32_t byte0, byte1, byte2, byte3, byte4;
+    uint64_t state0, state1, state2, state3, state4;
+
+    state0 = UTF8_ACCEPT;
+    state1 = UTF8_ACCEPT;
+    state2 = UTF8_ACCEPT;
+    state3 = UTF8_ACCEPT;
+    state4 = UTF8_ACCEPT;
+
+    while (len--) {
+        byte0 = *s0_start++;
+        byte1 = *s1_start++;
+        byte2 = *s2_start++;
+        byte3 = *s3_start++;
+        byte4 = *s4_start++;
+        byte0 = utf8d[byte0];
+        byte1 = utf8d[byte1];
+        byte2 = utf8d[byte2];
+        byte3 = utf8d[byte3];
+        byte4 = utf8d[byte4];
+        state0 = utf8s[state0 + byte0];
+        state1 = utf8s[state1 + byte1];
+        state2 = utf8s[state2 + byte2];
+        state3 = utf8s[state3 + byte3];
+        state4 = utf8s[state4 + byte4];
+    }
+
+    // finish the larger buffers
+    while (s4_start != s4_end) {
+        byte4 = *s4_start++;
+        byte4 = utf8d[byte4];
+        state4 = utf8s[state4 + byte4];
+    }
+    while (s3_start != s3_end) {
+        byte3 = *s3_start++;
+        byte3 = utf8d[byte3];
+        state3 = utf8s[state3 + byte3];
+    }
+    while (s2_start != s2_end) {
+        byte2 = *s2_start++;
+        byte2 = utf8d[byte2];
+        state2 = utf8s[state2 + byte2];
+    }
+    while (s1_start != s1_end) {
+        byte1 = *s1_start++;
+        byte1 = utf8d[byte1];
+        state1 = utf8s[state1 + byte1];
+    }
+    while (s0_start != s0_end) {
+        byte0 = *s0_start++;
+        byte0 = utf8d[byte0];
+        state0 = utf8s[state0 + byte0];
+    }
+
+    uint64_t fail = state0 | state1 | state2 | state3 | state4;
+    fail |= fail ? UTF8_REJECT : 0;
+    return (~fail) & UTF8_REJECT;
+}
+
+extern "C" int utf8dfa_2dfa(const unsigned char*, int);
+
+extern "C" int utf8dfa_5dfa(const unsigned char*, int);
+
+// Return 0 - success, -1 - error 
+int utf8dfa_2dfa(const unsigned char *data, int len) {
+    uint8_t* buf = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data));
+    return u_utf8_2dfa(buf, len) ? 0 : -1;
+}
+
+// Return 0 - success, -1 - error 
+int utf8dfa_5dfa(const unsigned char *data, int len) {
+    uint8_t* buf = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data));
+    return u_utf8_5dfa(buf, len) ? 0 : -1;
+}

--- a/utf8vec.cpp
+++ b/utf8vec.cpp
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <string.h>
+
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
+
+#include "utf8-simd.h"
+#include "utils.h"
+#include "utf8.h"
+
+// -----------------------------------------------------------------------------
+// Taken from  https://github.com/zwegner/faster-utf8-validator/blob/master/z_validate.c
+//
+// modified
+// - standard includes (stdint ...)
+// - buffer overflow in the last loop iteration (up to 31 bytes are read past input buffers)
+// - exact bounds about in length comparisons (offset + V_LEN <= len) 
+// - loadu -> lddqu (documentation says it is faster)
+// - fast ascii7 scan at the start
+// 
+// -----------------------------------------------------------------------------
+
+
+// vector length is 64 bytes
+#if defined (__AVX512F__)
+#define V_LEN 64
+#include "vecutf8.h"
+#endif
+
+// vector length is 32 bytes
+#if defined (__AVX2__)
+#define V_LEN 32
+#include "vecutf8.h"
+#endif
+
+extern "C" int utf8vec_avx512(const unsigned char*, int);
+
+extern "C" int utf8vec_avx2(const unsigned char*, int);
+
+// Return 0 - success, -1 - error 
+int utf8vec_avx2(const unsigned char *data, int len) {
+    uint8_t* buf = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data));
+    return u_utf8_d256(buf, len) ? 0 : -1;
+}
+
+// Return 0 - success, -1 - error 
+int utf8vec_avx512(const unsigned char *data, int len) {
+    uint8_t* buf = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data));
+    return u_utf8_d512(buf, len) ? 0 : -1;
+}

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,86 @@
+#pragma once
+
+
+#ifdef __SIZEOF_INT128__
+
+#include <x86intrin.h>
+    typedef unsigned __int128 uint128_t;
+#else
+
+#include <intrin.h>
+
+class uint128_t {
+public:
+    uint64_t lo, hi;
+    uint128_t(int v) { lo = v; hi = 0; }
+    uint128_t(uint32_t v) { lo = v; hi = 0; }
+    uint128_t(uint64_t v) { lo = v; hi = 0; }
+    uint128_t(uint64_t p_hi, uint64_t p_lo) { lo = p_lo; hi = p_hi; }
+
+    inline uint128_t &operator+=(const uint64_t &other) {
+        lo += other;
+        hi += (lo < other);
+        return *this;
+    }
+    inline uint128_t &operator+=(const uint128_t &other) {
+        lo += other.lo;
+        hi += (lo < other.lo);
+        hi += other.hi;
+        return *this;
+    }
+    inline uint128_t &operator&=(const uint128_t &other) {
+        lo &= other.lo;
+        hi &= other.hi;
+        return *this;
+    }
+    inline uint128_t &operator|=(const uint128_t &other) {
+        lo |= other.lo;
+        hi |= other.hi;
+        return *this;
+    }
+    inline uint128_t &operator^=(const uint128_t &other) {
+        lo ^= other.lo;
+        hi ^= other.hi;
+        return *this;
+    }
+    inline uint128_t &operator>>=(int amount) {
+        if (amount == 64) {
+            lo = hi;
+            hi = 0;
+            return *this;
+        }
+        if (amount >= 64)
+        {
+            lo = hi >> (amount - 64);
+            hi = 0;
+            return *this;
+        }
+        lo = (lo >> amount) | (hi << (64 - amount));
+        hi = hi >> amount;
+        return *this;
+    }
+    inline uint128_t &operator<<=(int amount) {
+        if (amount == 64) {
+            hi = lo;
+            lo = 0;
+            return *this;
+        }
+        if (amount >= 64) {
+            hi = lo << (amount - 64);
+            lo = 0;
+            return *this;
+        }
+        hi = (hi << amount) | (lo << (64 - amount));
+        lo = lo << amount;
+        return *this;
+    }
+
+    operator unsigned long long() const {
+        return lo;
+    }
+};
+
+inline bool operator==(const uint128_t &lhs, const int &rhs) { return lhs.lo == rhs && lhs.hi == 0; }
+inline bool operator!=(const uint128_t &lhs, const int &rhs) { return !(lhs == rhs); }
+
+#endif

--- a/vecutf8.h
+++ b/vecutf8.h
@@ -1,0 +1,932 @@
+// faster-utf8-validator
+//
+// Copyright (c) 2019 Zach Wegner
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// How this validator works:
+//
+//   [[[ UTF-8 refresher: UTF-8 encodes text in sequences of "code points",
+//   each one from 1-4 bytes. For each code point that is longer than one byte,
+//   the code point begins with a unique prefix that specifies how many bytes
+//   follow. All bytes in the code point after this first have a continuation
+//   marker. All code points in UTF-8 will thus look like one of the following
+//   binary sequences, with x meaning "don't care":
+//      1 byte:  0xxxxxxx
+//      2 bytes: 110xxxxx  10xxxxxx
+//      3 bytes: 1110xxxx  10xxxxxx  10xxxxxx
+//      4 bytes: 11110xxx  10xxxxxx  10xxxxxx  10xxxxxx
+//   ]]]
+//
+// This validator works in two basic steps: checking continuation bytes, and
+// handling special cases. Each step works on one vector's worth of input
+// bytes at a time.
+//
+// The continuation bytes are handled in a fairly straightforward manner in
+// the scalar domain. A mask is created from the input byte vector for each
+// of the highest four bits of every byte. The first mask allows us to quickly
+// skip pure ASCII input vectors, which have no bits set. The first and
+// (inverted) second masks together give us every continuation byte (10xxxxxx).
+// The other masks are used to find prefixes of multi-byte code points (110,
+// 1110, 11110). For these, we keep a "required continuation" mask, by shifting
+// these masks 1, 2, and 3 bits respectively forward in the byte stream. That
+// is, we take a mask of all bytes that start with 11, and shift it left one
+// bit forward to get the mask of all the first continuation bytes, then do the
+// same for the second and third continuation bytes. Here's an example input
+// sequence along with the corresponding masks:
+//
+//   bytes:        61 C3 80 62 E0 A0 80 63 F0 90 80 80 00
+//   code points:  61|C3 80|62|E0 A0 80|63|F0 90 80 80|00
+//   # of bytes:   1 |2  - |1 |3  -  - |1 |4  -  -  - |1
+//   cont. mask 1: -  -  1  -  -  1  -  -  -  1  -  -  -
+//   cont. mask 2: -  -  -  -  -  -  1  -  -  -  1  -  -
+//   cont. mask 3: -  -  -  -  -  -  -  -  -  -  -  1  -
+//   cont. mask *: 0  0  1  0  0  1  1  0  0  1  1  1  0
+//
+// The final required continuation mask is then compared with the mask of
+// actual continuation bytes, and must match exactly in valid UTF-8. The only
+// complication in this step is that the shifted masks can cross vector
+// boundaries, so we need to keep a "carry" mask of the bits that were shifted
+// past the boundary in the last loop iteration.
+//
+// Besides the basic prefix coding of UTF-8, there are several invalid byte
+// sequences that need special handling. These are due to three factors:
+// code points that could be described in fewer bytes, code points that are
+// part of a surrogate pair (which are only valid in UTF-16), and code points
+// that are past the highest valid code point U+10FFFF.
+//
+// All of the invalid sequences can be detected by independently observing
+// the first three nibbles of each code point. Since AVX2 can do a 4-bit/16-byte
+// lookup in parallel for all 32 bytes in a vector, we can create bit masks
+// for all of these error conditions, look up the bit masks for the three
+// nibbles for all input bytes, and AND them together to get a final error mask,
+// that must be all zero for valid UTF-8. This is somewhat complicated by
+// needing to shift the error masks from the first and second nibbles forward in
+// the byte stream to line up with the third nibble.
+//
+// We have these possible values for valid UTF-8 sequences, broken down
+// by the first three nibbles:
+//
+//   1st   2nd   3rd   comment
+//   0..7  0..F        ASCII
+//   8..B  0..F        continuation bytes
+//   C     2..F  8..B  C0 xx and C1 xx can be encoded in 1 byte
+//   D     0..F  8..B  D0..DF are valid with a continuation byte
+//   E     0     A..B  E0 8x and E0 9x can be encoded with 2 bytes
+//         1..C  8..B  E1..EC are valid with continuation bytes
+//         D     8..9  ED Ax and ED Bx correspond to surrogate pairs
+//         E..F  8..B  EE..EF are valid with continuation bytes
+//   F     0     9..B  F0 8x can be encoded with 3 bytes
+//         1..3  8..B  F1..F3 are valid with continuation bytes
+//         4     8     F4 8F BF BF is the maximum valid code point
+//
+// That leaves us with these invalid sequences, which would otherwise fit
+// into UTF-8's prefix encoding. Each of these invalid sequences needs to
+// be detected separately, with their own bits in the error mask.
+//
+//   1st   2nd   3rd   error bit
+//   C     0..1  0..F  0x01
+//   E     0     8..9  0x02
+//         D     A..B  0x04
+//   F     0     0..8  0x08
+//         4     9..F  0x10
+//         5..F  0..F  0x20
+//
+// For every possible value of the first, second, and third nibbles, we keep
+// a lookup table that contains the bitwise OR of all errors that that nibble
+// value can cause. For example, the first nibble has zeroes in every entry
+// except for C, E, and F, and the third nibble lookup has the 0x21 bits in
+// every entry, since those errors don't depend on the third nibble. After
+// doing a parallel lookup of the first/second/third nibble values for all
+// bytes, we AND them together. Only when all three have an error bit in common
+// do we fail validation.
+
+
+#if   V_LEN == 64
+// AVX512 definitions
+
+
+#   define z_validate_vec   z_validate_vec_512
+#   define z_dvalidate_utf8  u_utf8_d512
+#   define z_dvalidate_vec   z_dvalidate_vec_512
+#   define z_tvalidate_utf8  u_utf8_t512
+#   define z_tvalidate_vec   z_tvalidate_vec_512
+
+// Vector and vector mask types. We use #defines instead of typedefs so this
+// header can be included multiple times with different configurations
+
+#   define vec_t            __m512i
+#   define vmask_t          uint64_t
+#   define vmask2_t         uint128_t
+
+#   define v_load(x)        _mm512_loadu_si512((vec_t *)(x))
+#   define v_set1           _mm512_set1_epi8
+#   define v_and            _mm512_and_si512
+#   define v_or             _mm512_or_si512
+#   define v_test_bit7(input) _mm512_movepi8_mask(input)
+
+#   define v_test_bit(input, bit)                                           \
+        _mm512_movepi8_mask(_mm512_slli_epi16((input), 7 - (bit)))
+
+// Parallel table lookup for all bytes in a vector. We need to AND with 0x0F
+// for the lookup, because vpshufb has the neat "feature" that negative values
+// in an index byte will result in a zero.
+
+#   define v_lookup(table, index, mask, shift)                              \
+        _mm512_shuffle_epi8((table),                                        \
+                v_and(_mm512_srli_epi16((index), (shift)), (mask)))
+#   define v_lookup_no_shift(table, index, mask)                            \
+        _mm512_shuffle_epi8((table),                                        \
+                v_and((index), (mask)))
+
+#   define v_testz(a,b)          (_mm512_test_epi8_mask(a,b) == 0)
+
+// Simple macro to make a vector lookup table for use with vpshufb. Since
+// AVX2 is two 16-byte halves, we duplicate the input values.
+
+#   define V_TABLE_16(...)    _mm512_set_epi8(__VA_ARGS__, __VA_ARGS__,__VA_ARGS__, __VA_ARGS__)
+
+// Move all the bytes in "input" to the left by one and fill in the first byte
+// with zero. Since AVX2 generally works on two separate 16-byte vectors glued
+// together, this needs two steps. The permute2x128 takes the middle 32 bytes
+// of the 64-byte concatenation v_zero:input. The align then gives the final
+// result in each half:
+//      top half: input_L:input_H --> input_L[15]:input_H[0:14]
+//   bottom half:  zero_H:input_L -->  zero_H[15]:input_L[0:14]
+inline __m512i _mm512_slli_si512(__m512i a, uint8_t byteCount)
+{
+#ifdef __AVX512_VBMI2__
+    return _mm512_maskz_compress_epi8(-1LL << byteCount, a);
+#else
+    // set up temporary array and set lower half to zero 
+    // (this needs to happen outside any critical loop)
+    alignas(64) char temp[128];
+    _mm512_store_si512(temp, _mm512_setzero_si512());
+
+    // store input into upper half
+    _mm512_store_si512(temp + 64, a);
+
+    // load shifted register
+    return _mm512_loadu_si512(temp + (64 - byteCount));
+#endif
+}
+
+#   define v_shift_lanes_left(input)  _mm512_slli_si512(input, 1)
+
+
+#elif V_LEN == 32
+
+// AVX2 definitions
+
+
+#   define z_validate_vec   z_validate_vec_256
+#   define z_dvalidate_utf8  u_utf8_d256
+#   define z_dvalidate_vec   z_dvalidate_vec_256
+#   define z_tvalidate_utf8  u_utf8_t256
+#   define z_tvalidate_vec   z_tvalidate_vec_256
+
+// Vector and vector mask types. We use #defines instead of typedefs so this
+// header can be included multiple times with different configurations
+
+#   define vec_t            __m256i
+#   define vmask_t          uint32_t
+#   define vmask2_t         uint64_t
+
+#   define v_load(x)        _mm256_loadu_si256((vec_t *)(x))
+#   define v_set1           _mm256_set1_epi8
+#   define v_and            _mm256_and_si256
+#   define v_or             _mm256_or_si256
+#   define v_test_bit7(input) _mm256_movemask_epi8(input)
+
+#   define v_test_bit(input, bit)                                     \
+        _mm256_movemask_epi8(_mm256_slli_epi16((input), 7 - (bit)))
+
+// Parallel table lookup for all bytes in a vector. We need to AND with 0x0F
+// for the lookup, because vpshufb has the neat "feature" that negative values
+// in an index byte will result in a zero.
+
+#   define v_lookup(table, index, mask, shift)                        \
+                _mm256_shuffle_epi8((table),                          \
+                v_and(_mm256_srli_epi16((index), (shift)), (mask)))
+#   define v_lookup_no_shift(table, index, mask)                      \
+                _mm256_shuffle_epi8((table),                          \
+                v_and((index), (mask)))
+
+#   define v_testz(a,b)          (_mm256_testz_si256(a,b) == 1)
+
+// Simple macro to make a vector lookup table for use with vpshufb. Since
+// AVX2 is two 16-byte halves, we duplicate the input values.
+
+#   define V_TABLE_16(...)    _mm256_set_epi8(__VA_ARGS__, __VA_ARGS__)
+
+// Move all the bytes in "input" to the left by one and fill in the first byte
+// with zero. Since AVX2 generally works on two separate 16-byte vectors glued
+// together, this needs two steps. The permute2x128 takes the middle 32 bytes
+// of the 64-byte concatenation v_zero:input. The align then gives the final
+// result in each half:
+//      top half: input_L:input_H --> input_L[15]:input_H[0:14]
+//   bottom half:  zero_H:input_L -->  zero_H[15]:input_L[0:14]
+#   define v_shift_lanes_left(input)  _mm256_alignr_epi8((input), _mm256_permute2x128_si256((input), (input), 0x08), 15)
+
+#elif V_LEN == 16
+
+// SSE definitions. We require at least SSE4.1 for _mm_test_all_zeros()
+
+
+#   define z_validate_vec   z_validate_vec_128
+#   define z_dvalidate_utf8  u_utf8_d128
+#   define z_dvalidate_vec   z_dvalidate_vec_028
+#   define z_tvalidate_utf8  u_utf8_t128
+#   define z_tvalidate_vec   z_tvalidate_vec_128
+
+#   define vec_t            __m128i
+#   define vmask_t          uint16_t
+#   define vmask2_t         uint32_t
+
+#   define v_load(x)        _mm_lddqu_si128((vec_t *)(x))
+#   define v_set1           _mm_set1_epi8
+#   define v_and            _mm_and_si128
+#   define v_or             _mm_or_si128
+#   define v_test_bit7(input) _mm_movemask_epi8(input)
+
+#   define v_test_bit(input, bit)                                           \
+        _mm_movemask_epi8(_mm_slli_epi16((input), (uint8_t)(7 - (bit))))
+
+#   define v_lookup(table, index, mask, shift)                              \
+                _mm_shuffle_epi8((table),                                   \
+                v_and(_mm_srli_epi16((index), (shift)), (mask)))
+#   define v_lookup_no_shift(table, index, mask)                            \
+                _mm_shuffle_epi8((table),                                   \
+                v_and((index), (mask)))
+
+#   define v_testz(a,b)          (_mm_testz_si128(a,b) == 1)
+
+#   define V_TABLE_16(...)  _mm_set_epi8(__VA_ARGS__)
+
+#   define v_shift_lanes_left v_shift_lanes_left_sse4
+
+static inline vec_t v_shift_lanes_left(vec_t top)
+{
+    return _mm_alignr_epi8(top, v_set1(0), 15);
+}
+
+#elif V_LEN == 8
+
+// SSE definitions. We require at least SSE4.1 for _mm_test_all_zeros()
+
+
+#   define z_validate_vec   z_validate_vec_64
+#   define z_dvalidate_utf8  u_utf8_d128
+#   define z_dvalidate_vec   z_dvalidate_vec_64
+#   define z_tvalidate_utf8  u_utf8_t64
+#   define z_tvalidate_vec   z_tvalidate_vec_64
+
+#   define vec_t            uint64_t
+#   define vmask_t          uint8_t
+#   define vmask2_t         uint16_t
+
+#   define v_load(x)        *((vec_t *)(x))
+#   define v_set1(x)        (x | (x << 8) | (x << 16) | (x << 24) | (x << 32) | (x << 40) | (x << 48) | (x << 56)) 
+#   define v_and(x, y)      (x & y)
+#   define v_or(x, y)      (x | y)
+#   define v_test_bit7(input) _pext_u32((input), 0x8080808080808080ull)
+
+#   define v_test_bit(input, bit)                                           \
+        _pext_u32((input) << (7 - (bit)), 0x8080808080808080ull))
+
+#   define v_lookup(table, index, mask, shift)                              \
+        _mm_shuffle_epi8((table),                                           \
+                v_and(_mm_srli_epi16((index), (shift)), (mask)))
+#   define v_lookup_no_shift(table, index, mask)                                    \
+        _mm_shuffle_epi8((table),                                           \
+                v_and((index), (mask)))
+
+#   define v_testz(a,b)          (((a) & (b)) == 0)
+
+#   define V_TABLE_16(...)  _mm_set_epi8(__VA_ARGS__)
+
+#   define v_shift_lanes_left v_shift_lanes_left_64
+
+static inline vec_t v_shift_lanes_left(vec_t top)
+{
+    return top << 8;
+}
+
+#else
+
+#   error "No valid configuration: must define one of the vector length V_LEN, and AVX512, AVX2 or SSE4.2"
+
+#endif
+
+
+// force inlining
+#ifdef _MSC_VER
+#define INLINE  __forceinline
+#elif defined (__GNUC__)
+#define INLINE __attribute__((always_inline)) inline
+#else
+#define INLINE inline
+#endif
+
+
+static INLINE bool z_validate_vec(vec_t bytes, vec_t shifted_bytes, vmask_t *last_cont);
+
+// Validate one vector's worth of input bytes
+static INLINE bool z_validate_vec(vec_t bytes, vec_t shifted_bytes, vmask_t *last_cont)
+{
+    // Error lookup tables for the first, second, and third nibbles
+    const vec_t error_1 = V_TABLE_16(
+        0x38, 0x06, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00
+    );
+    const vec_t error_2 = V_TABLE_16(
+        0x20, 0x20, 0x24, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x10,
+        0x00, 0x00, 0x01, 0x0B
+    );
+    const vec_t error_3 = V_TABLE_16(
+        0x31, 0x31, 0x31, 0x31,
+        0x35, 0x35, 0x33, 0x2B,
+        0x29, 0x29, 0x29, 0x29,
+        0x29, 0x29, 0x29, 0x29
+    );
+
+    // Quick skip for ascii-only input. If there are no bytes with the high bit
+    // set, we don't need to do any more work. We return either valid or
+    // invalid based on whether we expected any continuation bytes here.
+    vmask_t high = v_test_bit7(bytes);
+    if (!high)
+        return *last_cont == 0;
+
+    bool pass = true;
+    // Which bytes are required to be continuation bytes
+    vmask2_t req = *last_cont;
+    // A bitmask of the actual continuation bytes in the input
+    vmask_t cont;
+
+    // Compute the continuation byte mask by finding bytes that start with
+    // 11x, 111x, and 1111. For each of these prefixes, we get a bitmask
+    // and shift it forward by 1, 2, or 3. This loop should be unrolled by
+    // the compiler, and the (n == 1) branch inside eliminated.
+    vmask_t set = high;
+    set &= v_test_bit(bytes, 6);
+    // Mark continuation bytes: those that have the high bit set but
+    // not the next one
+    cont = high ^ set;
+
+    // We add the shifted mask here instead of ORing it, which would
+    // be the more natural operation, so that this line can be done
+    // with one lea. While adding could give a different result due
+    // to carries, this will only happen for invalid UTF-8 sequences,
+    // and in a way that won't cause it to pass validation. Reasoning:
+    // Any bits for required continuation bytes come after the bits
+    // for their leader bytes, and are all contiguous. For a carry to
+    // happen, two of these bit sequences would have to overlap. If
+    // this is the case, there is a leader byte before the second set
+    // of required continuation bytes (and thus before the bit that
+    // will be cleared by a carry). This leader byte will not be
+    // in the continuation mask, despite being required. QEDish.
+    req += (vmask2_t)set << 1;
+    set &= v_test_bit(bytes, 5);
+    req += (vmask2_t)set << 2;
+    set &= v_test_bit(bytes, 4);
+    req += (vmask2_t)set << 3;
+
+    // Check that continuation bytes match. We must cast req from vmask2_t
+    // (which holds the carry mask in the upper half) to vmask_t, which
+    // zeroes out the upper bits
+    pass &= cont == (vmask_t)req;
+
+    // Look up error masks for three consecutive nibbles.
+    vec_t mask = v_set1(0x0F);
+    vec_t e_1 = v_lookup(error_1, shifted_bytes, mask, 4);
+    vec_t e_2 = v_lookup_no_shift(error_2, shifted_bytes, mask);
+    vec_t e_3 = v_lookup(error_3, bytes, mask, 4);
+
+    // Check if any bits are set in all three error masks
+    pass &= v_testz(v_and(e_1, e_2), e_3) != 0;
+
+    // Save continuation bits and input bytes for the next round
+    *last_cont = req >> V_LEN;
+
+    return pass;
+}
+
+static INLINE bool z_dvalidate_vec(vec_t bytes0, vec_t shifted_bytes0, vmask_t *last_cont0, vec_t bytes1, vec_t shifted_bytes1, vmask_t *last_cont1);
+
+// Validate two vector's worth of input bytes
+static INLINE bool z_dvalidate_vec(vec_t bytes0, vec_t shifted_bytes0, vmask_t *last_cont0, vec_t bytes1, vec_t shifted_bytes1, vmask_t *last_cont1)
+{
+    // Error lookup tables for the first, second, and third nibbles
+    const vec_t error_1 = V_TABLE_16(
+        0x38, 0x06, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00
+    );
+    const vec_t error_2 = V_TABLE_16(
+        0x20, 0x20, 0x24, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x10,
+        0x00, 0x00, 0x01, 0x0B
+    );
+    const vec_t error_3 = V_TABLE_16(
+        0x31, 0x31, 0x31, 0x31,
+        0x35, 0x35, 0x33, 0x2B,
+        0x29, 0x29, 0x29, 0x29,
+        0x29, 0x29, 0x29, 0x29
+    );
+
+    // Which bytes are required to be continuation bytes
+    vmask2_t req0 = *last_cont0;
+    vmask2_t req1 = *last_cont1;
+    // A bitmask of the actual continuation bytes in the input
+    vmask_t cont0, cont1;
+
+    // Compute the continuation byte mask by finding bytes that start with
+    // 11x, 111x, and 1111. For each of these prefixes, we get a bitmask
+    // and shift it forward by 1, 2, or 3. This loop should be unrolled by
+    // the compiler, and the (n == 1) branch inside eliminated.
+    vmask_t high0 = v_test_bit7(bytes0);
+    vmask_t high1 = v_test_bit7(bytes1);
+    vmask_t set0 = high0 & v_test_bit(bytes0, 6);
+    vmask_t set1 = high1 & v_test_bit(bytes1, 6);
+    cont0 = high0 ^ set0;
+    cont1 = high1 ^ set1;
+    req0 += (vmask2_t)set0 << 1;
+    req1 += (vmask2_t)set1 << 1;
+    set0 &= v_test_bit(bytes0, 5);
+    set1 &= v_test_bit(bytes1, 5);
+    req0 += (vmask2_t)set0 << 2;
+    req1 += (vmask2_t)set1 << 2;
+    set0 &= v_test_bit(bytes0, 4);
+    set1 &= v_test_bit(bytes1, 4);
+    req0 += (vmask2_t)set0 << 3;
+    req1 += (vmask2_t)set1 << 3;
+
+    // Check that continuation bytes match. We must cast req from vmask2_t
+    // (which holds the carry mask in the upper half) to vmask_t, which
+    // zeroes out the upper bits
+    bool pass = (cont0 == (vmask_t)req0);
+    pass &= (cont1 == (vmask_t)req1);
+
+    // Look up error masks for three consecutive nibbles.
+    vec_t mask0f = v_set1(0x0f);
+    vec_t e_10 = v_lookup(error_1, shifted_bytes0, mask0f, 4);
+    vec_t e_11 = v_lookup(error_1, shifted_bytes1, mask0f, 4);
+    vec_t e_20 = v_lookup_no_shift(error_2, shifted_bytes0, mask0f);
+    vec_t e_21 = v_lookup_no_shift(error_2, shifted_bytes1, mask0f);
+    vec_t e_30 = v_lookup(error_3, bytes0, mask0f, 4);
+    vec_t e_31 = v_lookup(error_3, bytes1, mask0f, 4);
+
+    // Check if any bits are set in all three error masks
+    pass &= v_testz(v_and(e_10, e_20), e_30) != 0;
+    pass &= v_testz(v_and(e_11, e_21), e_31) != 0;
+
+    // Save continuation bits and input bytes for the next round
+    *last_cont0 = req0 >> V_LEN;
+    *last_cont1 = req1 >> V_LEN;
+    return pass;
+}
+
+static INLINE bool z_tvalidate_vec(vec_t bytes0, vec_t shifted_bytes0, vmask_t *last_cont0,
+    vec_t bytes1, vec_t shifted_bytes1, vmask_t *last_cont1,
+    vec_t bytes2, vec_t shifted_bytes2, vmask_t *last_cont2);
+
+// Validate two vector's worth of input bytes
+static INLINE bool z_tvalidate_vec(vec_t bytes0, vec_t shifted_bytes0, vmask_t *last_cont0,
+    vec_t bytes1, vec_t shifted_bytes1, vmask_t *last_cont1,
+    vec_t bytes2, vec_t shifted_bytes2, vmask_t *last_cont2)
+{
+    // Error lookup tables for the first, second, and third nibbles
+    const vec_t error_1 = V_TABLE_16(
+        0x38, 0x06, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00
+    );
+    const vec_t error_2 = V_TABLE_16(
+        0x20, 0x20, 0x24, 0x20,
+        0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x10,
+        0x00, 0x00, 0x01, 0x0B
+    );
+    const vec_t error_3 = V_TABLE_16(
+        0x31, 0x31, 0x31, 0x31,
+        0x35, 0x35, 0x33, 0x2B,
+        0x29, 0x29, 0x29, 0x29,
+        0x29, 0x29, 0x29, 0x29
+    );
+
+    // Which bytes are required to be continuation bytes
+    vmask2_t req0 = *last_cont0;
+    vmask2_t req1 = *last_cont1;
+    vmask2_t req2 = *last_cont2;
+    // A bitmask of the actual continuation bytes in the input
+    vmask_t cont0, cont1, cont2;
+
+    // Compute the continuation byte mask by finding bytes that start with
+    // 11x, 111x, and 1111. For each of these prefixes, we get a bitmask
+    // and shift it forward by 1, 2, or 3. This loop should be unrolled by
+    // the compiler, and the (n == 1) branch inside eliminated.
+    vmask_t high0 = v_test_bit7(bytes0);
+    vmask_t high1 = v_test_bit7(bytes1);
+    vmask_t high2 = v_test_bit7(bytes2);
+    vmask_t set0 = high0 & v_test_bit(bytes0, 6);
+    vmask_t set1 = high1 & v_test_bit(bytes1, 6);
+    vmask_t set2 = high2 & v_test_bit(bytes2, 6);
+    cont0 = high0 ^ set0;
+    cont1 = high1 ^ set1;
+    cont2 = high2 ^ set2;
+    req0 += (vmask2_t)set0 << 1;
+    req1 += (vmask2_t)set1 << 1;
+    req2 += (vmask2_t)set2 << 1;
+    set0 &= v_test_bit(bytes0, 5);
+    set1 &= v_test_bit(bytes1, 5);
+    set2 &= v_test_bit(bytes2, 5);
+    req0 += (vmask2_t)set0 << 2;
+    req1 += (vmask2_t)set1 << 2;
+    req2 += (vmask2_t)set2 << 2;
+    set0 &= v_test_bit(bytes0, 4);
+    set1 &= v_test_bit(bytes1, 4);
+    set2 &= v_test_bit(bytes2, 4);
+    req0 += (vmask2_t)set0 << 3;
+    req1 += (vmask2_t)set1 << 3;
+    req2 += (vmask2_t)set2 << 3;
+
+    // Check that continuation bytes match. We must cast req from vmask2_t
+    // (which holds the carry mask in the upper half) to vmask_t, which
+    // zeroes out the upper bits
+    bool pass = (cont0 == (vmask_t)req0);
+    pass &= (cont1 == (vmask_t)req1);
+    pass &= (cont2 == (vmask_t)req2);
+
+    // Look up error masks for three consecutive nibbles.
+    vec_t mask0f = v_set1(0x0f);
+    vec_t e_10 = v_lookup(error_1, shifted_bytes0, mask0f, 4);
+    vec_t e_11 = v_lookup(error_1, shifted_bytes1, mask0f, 4);
+    vec_t e_12 = v_lookup(error_1, shifted_bytes2, mask0f, 4);
+    vec_t e_20 = v_lookup_no_shift(error_2, shifted_bytes0, mask0f);
+    vec_t e_21 = v_lookup_no_shift(error_2, shifted_bytes1, mask0f);
+    vec_t e_22 = v_lookup_no_shift(error_2, shifted_bytes2, mask0f);
+    vec_t e_30 = v_lookup(error_3, bytes0, mask0f, 4);
+    vec_t e_31 = v_lookup(error_3, bytes1, mask0f, 4);
+    vec_t e_32 = v_lookup(error_3, bytes2, mask0f, 4);
+
+    // Check if any bits are set in all three error masks
+    pass &= v_testz(v_and(e_10, e_20), e_30) != 0;
+    pass &= v_testz(v_and(e_11, e_21), e_31) != 0;
+    pass &= v_testz(v_and(e_12, e_22), e_32) != 0;
+
+    // Save continuation bits and input bytes for the next round
+    *last_cont0 = req0 >> V_LEN;
+    *last_cont1 = req1 >> V_LEN;
+    *last_cont2 = req2 >> V_LEN;
+    return pass;
+}
+
+
+bool z_dvalidate_utf8(const uint8_t *data, uint32_t len)
+{
+    vec_t bytes0, shifted_bytes0;
+    vec_t bytes1, shifted_bytes1;
+
+    if (V_LEN <= len)
+    {
+        // quickly filter out ascii7 (trimm both sides of the input buffer)
+        while (2 * V_LEN <= len)
+        {
+            bytes0 = v_load(data);
+            bytes1 = v_load(data + len - V_LEN);
+            if (v_test_bit7(v_or(bytes0, bytes1))) break;  // not ascii7
+            data += V_LEN;
+            len -= 2 * V_LEN;
+        }
+        while (V_LEN <= len)
+        {
+            bytes0 = v_load(data);
+            if (v_test_bit7(bytes0)) break;  // not ascii7
+            data += V_LEN;
+            len -= V_LEN;
+        }
+    }
+
+    const uint8_t *end1 = data + len;
+    const uint8_t *data1 = utf8MidBoundary(data, end1, 2);
+    const uint8_t *end0 = data1;
+    const uint8_t *data0 = data;
+    uint32_t len0 = (uint32_t)(end0 - data0);
+    uint32_t len1 = (uint32_t)(end1 - data1);
+    vmask_t last_cont0 = 0;
+    vmask_t last_cont1 = 0;
+    len = len0 < len1 ? len0 : len1;
+
+    // Deal with the input up until the last section of bytes
+    if (len >= V_LEN)
+    {
+        // Keep continuation bits from the previous iteration that carry over to
+        // each input chunk vector
+
+        // We need a vector of the input byte stream shifted forward one byte.
+        // Since we don't want to read the memory before the data pointer
+        // (which might not even be mapped), for the first chunk of input just
+        // use vector instructions.
+        bytes0 = v_load(data0);
+        bytes1 = v_load(data1);
+        shifted_bytes0 = v_shift_lanes_left(bytes0);
+        shifted_bytes1 = v_shift_lanes_left(bytes1);
+
+        // Loop over input in V_LEN-byte chunks, as long as we can safely read
+        // that far into memory
+        while (len >= 2 * V_LEN)
+        {
+            if (!z_dvalidate_vec(bytes0, shifted_bytes0, &last_cont0, bytes1, shifted_bytes1, &last_cont1))
+                return false;
+            len -= V_LEN;
+            shifted_bytes0 = v_load(data0 + V_LEN - 1);
+            shifted_bytes1 = v_load(data1 + V_LEN - 1);
+            data0 += V_LEN;
+            data1 += V_LEN;
+            bytes0 = v_load(data0);
+            bytes1 = v_load(data1);
+        }
+        if (data0 + V_LEN <= end0)
+        {
+            if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+                return false;
+            data0 += V_LEN;
+        }
+        if (data1 + V_LEN <= end1)
+        {
+            if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+                return false;
+            data1 += V_LEN;
+        }
+    }
+    while (data0 + V_LEN <= end0)
+    {
+        bytes0 = v_load(data0);
+        shifted_bytes0 = v_shift_lanes_left(bytes0);
+        if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+            return false;
+        data0 += V_LEN;
+    }
+    while (data1 + V_LEN <= end1)
+    {
+        bytes1 = v_load(data1);
+        shifted_bytes1 = v_shift_lanes_left(bytes1);
+        if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+            return false;
+        data1 += V_LEN;
+    }
+
+    // Deal with any bytes remaining. Rather than making a separate scalar path,
+    // just fill in a buffer, reading bytes only up to len, and load from that.
+    if (data0 < end0)
+    {
+        char buffer[V_LEN + 1] = { 0 };
+        unsigned i = 1;
+        if (data0 - data)
+            buffer[0] = data0[-1];
+        while (data0 < end0)
+            buffer[i++] = *data0++;
+
+        bytes0 = v_load(buffer + 1);
+        shifted_bytes0 = v_load(buffer);
+        if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+            return false;
+    }
+    if (data1 < end1)
+    {
+        char buffer[V_LEN + 1] = { 0 };
+        unsigned i = 1;
+        if (data1 - data)
+            buffer[0] = data1[-1];
+        while (data1 < end1)
+            buffer[i++] = *data1++;
+
+        bytes1 = v_load(buffer + 1);
+        shifted_bytes1 = v_load(buffer);
+        if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+            return false;
+    }
+
+    // The input is valid if we don't have any more expected continuation bytes
+    return last_cont0 == 0 && last_cont1 == 0;
+}
+
+bool z_tvalidate_utf8(const uint8_t *data, uint32_t len)
+{
+    vec_t bytes0, shifted_bytes0;
+    vec_t bytes1, shifted_bytes1;
+    vec_t bytes2, shifted_bytes2;
+
+    if (V_LEN <= len)
+    {
+        // quickly filter out ascii7 (trimm both sides of the input buffer)
+        while (2 * V_LEN <= len)
+        {
+            bytes0 = v_load(data);
+            bytes1 = v_load(data + len - V_LEN);
+            if (v_test_bit7(v_or(bytes0, bytes1))) break;  // not ascii7
+            data += V_LEN;
+            len -= 2 * V_LEN;
+        }
+        while (V_LEN <= len)
+        {
+            bytes0 = v_load(data);
+            if (v_test_bit7(bytes0)) break;  // not ascii7
+            data += V_LEN;
+            len -= V_LEN;
+        }
+    }
+
+
+    const uint8_t *end2 = data + len;
+    const uint8_t *data2 = utf8MidBoundary(data, end2, 3);
+    const uint8_t *end1 = data2;
+    const uint8_t *data1 = utf8MidBoundary(data, end1, 2);
+    const uint8_t *end0 = data1;
+    const uint8_t *data0 = data;
+
+    // find the smallest buffer
+    uint32_t len0 = (uint32_t)(end0 - data0);
+    uint32_t len1 = (uint32_t)(end1 - data1);
+    uint32_t len2 = (uint32_t)(end2 - data2);
+    len = len0 < len1 ? len0 : len1;
+    len = len < len2 ? len : len2;
+
+    vmask_t last_cont0 = 0;
+    vmask_t last_cont1 = 0;
+    vmask_t last_cont2 = 0;
+
+    // Deal with the input up until the last section of bytes
+    if (len >= V_LEN)
+    {
+        // Keep continuation bits from the previous iteration that carry over to
+        // each input chunk vector
+
+        // We need a vector of the input byte stream shifted forward one byte.
+        // Since we don't want to read the memory before the data pointer
+        // (which might not even be mapped), for the first chunk of input just
+        // use vector instructions.
+        bytes0 = v_load(data0);
+        bytes1 = v_load(data1);
+        bytes2 = v_load(data2);
+        shifted_bytes0 = v_shift_lanes_left(bytes0);
+        shifted_bytes1 = v_shift_lanes_left(bytes1);
+        shifted_bytes2 = v_shift_lanes_left(bytes2);
+
+        // Loop over input in V_LEN-byte chunks, as long as we can safely read
+        // that far into memory
+        while (len >= 2 * V_LEN)
+        {
+            if (!z_tvalidate_vec(bytes0, shifted_bytes0, &last_cont0, bytes1, shifted_bytes1, &last_cont1, bytes2, shifted_bytes2, &last_cont2))
+                return false;
+            len -= V_LEN;
+            shifted_bytes0 = v_load(data0 + V_LEN - 1);
+            shifted_bytes1 = v_load(data1 + V_LEN - 1);
+            shifted_bytes2 = v_load(data2 + V_LEN - 1);
+            data0 += V_LEN;
+            data1 += V_LEN;
+            data2 += V_LEN;
+            bytes0 = v_load(data0);
+            bytes1 = v_load(data1);
+            bytes2 = v_load(data2);
+        }
+        if (data0 + V_LEN <= end0)
+        {
+            if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+                return false;
+            data0 += V_LEN;
+        }
+        if (data1 + V_LEN <= end1)
+        {
+            if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+                return false;
+            data1 += V_LEN;
+        }
+        if (data2 + V_LEN <= end2)
+        {
+            if (!z_validate_vec(bytes2, shifted_bytes2, &last_cont2))
+                return false;
+            data2 += V_LEN;
+        }
+    }
+    while (data0 + V_LEN <= end0)
+    {
+        bytes0 = v_load(data0);
+        shifted_bytes0 = v_shift_lanes_left(bytes0);
+        if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+            return false;
+        data0 += V_LEN;
+    }
+    while (data1 + V_LEN <= end1)
+    {
+        bytes1 = v_load(data1);
+        shifted_bytes1 = v_shift_lanes_left(bytes1);
+        if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+            return false;
+        data1 += V_LEN;
+    }
+    while (data2 + V_LEN <= end2)
+    {
+        bytes2 = v_load(data2);
+        shifted_bytes2 = v_shift_lanes_left(bytes2);
+        if (!z_validate_vec(bytes2, shifted_bytes2, &last_cont2))
+            return false;
+        data2 += V_LEN;
+    }
+
+    // Deal with any bytes remaining. Rather than making a separate scalar path,
+    // just fill in a buffer, reading bytes only up to len, and load from that.
+    if (data0 < end0)
+    {
+        char buffer[V_LEN + 1] = { 0 };
+        unsigned i = 1;
+        if (data0 - data)
+            buffer[0] = data0[-1];
+        while (data0 < end0)
+            buffer[i++] = *data0++;
+
+        bytes0 = v_load(buffer + 1);
+        shifted_bytes0 = v_load(buffer);
+        if (!z_validate_vec(bytes0, shifted_bytes0, &last_cont0))
+            return false;
+    }
+    if (data1 < end1)
+    {
+        char buffer[V_LEN + 1] = { 0 };
+        unsigned i = 1;
+        if (data1 - data)
+            buffer[0] = data1[-1];
+        while (data1 < end1)
+            buffer[i++] = *data1++;
+
+        bytes1 = v_load(buffer + 1);
+        shifted_bytes1 = v_load(buffer);
+        if (!z_validate_vec(bytes1, shifted_bytes1, &last_cont1))
+            return false;
+    }
+    if (data2 < end2)
+    {
+        char buffer[V_LEN + 1] = { 0 };
+        unsigned i = 1;
+        if (data2 - data)
+            buffer[0] = data2[-1];
+        while (data2 < end2)
+            buffer[i++] = *data2++;
+
+        bytes2 = v_load(buffer + 1);
+        shifted_bytes2 = v_load(buffer);
+        if (!z_validate_vec(bytes2, shifted_bytes2, &last_cont2))
+            return false;
+    }
+
+    // The input is valid if we don't have any more expected continuation bytes
+    return last_cont0 == 0 && last_cont1 == 0 && last_cont2 == 0;
+}
+
+// Undefine all macros
+
+#undef INLINE
+#undef z_validate_vec
+#undef z_dvalidate_utf8
+#undef z_dvalidate_vec
+#undef z_tvalidate_utf8
+#undef z_tvalidate_vec
+#undef V_LEN
+#undef vec_t
+#undef vmask_t
+#undef vmask2_t
+#undef v_load
+#undef v_set1
+#undef v_and
+#undef v_or
+#undef v_test_bit
+#undef v_test_bit7
+#undef v_testz
+#undef v_lookup
+#undef v_lookup_no_shift
+#undef V_TABLE_16
+#undef v_shift_lanes_left
+


### PR DESCRIPTION
This PR has changes made to the UTF-8 validation function. These were mainly done in the IsStructurallyValidUTF8 function, which previously lived in src/google/protobuf/stubs/structurally_valid.cc. I noticed that the code around this functionality has been moved to utf8-range module. Based on the length of the buffer and also based on the availability of certain instructions in the CPU, a certain implementation will be selected. To take advantage of the optimizations, the code should be compiled `-march=native`.